### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-# app/Dockerfile
-
-FROM python:3.9-slim
-
+FROM python:3.11-slim
 WORKDIR /app
-
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    software-properties-common \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/idofrizler/bingeworthy .
-
-RUN pip3 install -r requirements.txt
-
 EXPOSE 8501
-
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
+RUN --mount=type=cache,target=/var/cache/apt \
+  apt-get update && apt-get install -y --no-install-recommends curl
+COPY requirements.txt .
+RUN --mount=type=cache,target=/root/.cache \
+  pip install -r requirements.txt
+
+COPY main.py .
 ENTRYPOINT ["streamlit", "run", "main.py", "--server.port=8501", "--server.address=0.0.0.0", "--server.enableCORS=true"]


### PR DESCRIPTION
* Update Python to 3.11.
* Copy from the current directory instead of cloning.
* Employ cache.

This reduces the image from 1.1G to 586M.