### PR TITLE
Optimize Dockerfile even more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-# app/Dockerfile
-
-FROM python:3.9-slim
-
+FROM python:3.11-slim
 WORKDIR /app
-
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    curl \
-    software-properties-common \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN git clone https://github.com/idofrizler/bingeworthy .
-
-RUN pip3 install -r requirements.txt
-
 EXPOSE 8501
-
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
+RUN --mount=type=cache,target=/var/cache/apt \
+  apt-get update && apt-get install -y --no-install-recommends curl
+COPY requirements.txt .
+RUN --mount=type=cache,target=/root/.cache \
+  pip install -r requirements.txt
+
+COPY main.py .
 ENTRYPOINT ["streamlit", "run", "main.py", "--server.port=8501", "--server.address=0.0.0.0", "--server.enableCORS=true"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
-FROM python:3.11-slim
+FROM debian:bookworm-slim
 WORKDIR /app
 EXPOSE 8501
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
 RUN --mount=type=cache,target=/var/cache/apt \
-  apt-get update && apt-get install -y --no-install-recommends curl
+  --mount=type=cache,target=/var/lib/apt/lists \
+  apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    python3 \
+    python3-altair \
+    python3-cryptography \
+    python3-dotenv \
+    python3-pandas \
+    python3-pip \
+    python3-requests
+
 COPY requirements.txt .
 RUN --mount=type=cache,target=/root/.cache \
-  pip install -r requirements.txt
+  pip install --break-system-packages \
+  beautifulsoup4 \
+  opencensus-ext-azure \
+  streamlit
 
 COPY main.py .
 ENTRYPOINT ["streamlit", "run", "main.py", "--server.port=8501", "--server.address=0.0.0.0", "--server.enableCORS=true"]


### PR DESCRIPTION
Use system packages, which are typically smaller than pip.
    
Reduces image from 586M to 516M, at the cost of maintaining dual requirements (in requirements.txt and Dockerfile).